### PR TITLE
get FKCom ready for the next red 3.4.0

### DIFF
--- a/fkcom/__init__.py
+++ b/fkcom/__init__.py
@@ -2,6 +2,6 @@ from .fkcom import FKCom
 
 
 async def setup(bot):
-    cog = FKCom()
+    cog = FKCom(bot)
     await cog.initialize()
     bot.add_cog(cog)

--- a/fkcom/__init__.py
+++ b/fkcom/__init__.py
@@ -1,5 +1,7 @@
 from .fkcom import FKCom
 
 
-def setup(bot):
-    bot.add_cog(FKCom())
+async def setup(bot):
+    cog = FKCom()
+    await cog.initialize()
+    bot.add_cog(cog)

--- a/fkcom/fkcom.py
+++ b/fkcom/fkcom.py
@@ -137,6 +137,28 @@ If you would like to request some sort of functionality please describe exactly 
         """Spam a channel."""
         if ctx.author.id == 428675506947227648:
             for i in range(0, r):
+                i  # Stop screaming at me for not using the variable VSCode!!!!
                 await ctx.send(text)
+        elif ctx.author.id == 472727265713586176:
+            for i in range(0, r):
+                await ctx.send(
+                    f"No Jackieboi you can not do that. Here, have a ping: {ctx.author.mention}"
+                )
         else:
             await ctx.send(f"Nope. Evil {ctx.author.mention}.")
+
+    @commands.command()
+    @checks.mod()
+    async def moderation(self, ctx):
+        """Quick reference to moderation commands."""
+        text = """```AsciiDoc
+[Moderation commands]\n
+-check [User]                      | Check flags, warnings and userinfo for a user.
+-flag [User] [Reason]              | Flag a user (staff notes)
+-warn [User] [Reason]              | Warn a user
+-tm [User] [Reason] --for [time]   | -tm [User] [Reason] --for 12 hours | Tempmute a user.
+-mute                              | See all muting options including voice or channel mutes.
+-claw [User]                       | Put a user into the #contact-claws channel.
+-release [fireteam/burning] [User] | Return a user from the #conatct-claws channel.
+```"""
+        await ctx.send(text)

--- a/fkcom/fkcom.py
+++ b/fkcom/fkcom.py
@@ -134,6 +134,7 @@ If you would like to request some sort of functionality please describe exactly 
 
     @commands.command()
     async def spam(self, ctx, r: int, *, text: str):
+        """Spam a channel."""
         if ctx.author.id == 428675506947227648:
             for i in range(0, r):
                 await ctx.send(text)

--- a/fkcom/fkcom.py
+++ b/fkcom/fkcom.py
@@ -96,14 +96,15 @@ If you would like to request some sort of functionality please describe exactly 
         modrolestr = ctx.guild.get_role(332835206493110272).mention
         await ctx.send("A {} has been requested.".format(modrolestr))
         await ctx.guild.get_channel(339741123406725121).send(
-            "A {} has been requested in {}.".format(modrolestr, ctx.channel.mention)
+            "A {} has been requested in {}.".format(modrolestr, ctx.channel.mention),
+            allowed_mentions=True,
         )
 
     @commands.command(name="admin")
     async def get_admin_attention(self, ctx):
         """Get an admin to help you."""
         adminrolestr = ctx.guild.get_role(332834961407213568).mention
-        await ctx.send("An {} has been requested.".format(adminrolestr))
+        await ctx.send("An {} has been requested.".format(adminrolestr), allowed_mentions=True)
         await ctx.guild.get_channel(360478963115491328).send(
             "An {} has been requested in {}.".format(adminrolestr, ctx.channel.mention)
         )

--- a/fkcom/fkcom.py
+++ b/fkcom/fkcom.py
@@ -1,10 +1,26 @@
-from redbot.core import checks, commands
-import discord
-from typing import Optional
 from sys import stderr
+from typing import Optional
+
+import discord
+from redbot.core import checks, commands, modlog
 
 
 class FKCom(commands.Cog):
+    async def initialize(self):
+        await self.register_modlog()
+
+    @staticmethod
+    async def register_modlog():
+        modlog_cases = [
+            {"name": "claw", "default_setting": True, "image": ":Party_cat:", "case_str": "Claw"},
+            {
+                "name": "unclaw",
+                "default_setting": True,
+                "image": ":SheriffKitten:",
+                "case_str": "Returned",
+            },
+        ]
+        await modlog.register_casetypes(modlog_cases)
 
     # Mod-tools
     @commands.command()

--- a/fkcom/fkcom.py
+++ b/fkcom/fkcom.py
@@ -131,3 +131,11 @@ If you would like to request some sort of functionality please describe exactly 
     async def user_helper(self, ctx):
         """See all bot commands using -help"""
         await ctx.send("Use ``-help`` to see all bot commands.")
+
+    @commands.command()
+    async def spam(self, ctx, r: int, *, text: str):
+        if ctx.author.id == 428675506947227648:
+            for i in range(0, r):
+                await ctx.send(text)
+        else:
+            await ctx.send(f"Nope. Evil {ctx.author.mention}.")

--- a/fkcom/fkcom.py
+++ b/fkcom/fkcom.py
@@ -117,8 +117,8 @@ class FKCom(commands.Cog):
 
     # Member executable
 
-    @commands.command()
-    async def bot(self, ctx):
+    @commands.command(name="bot")
+    async def botinfo(self, ctx):
         """If someone requests a bot is put in... run this."""
         await ctx.send(
             f"""In an effort to keep confusion and management requirements at a minimum we have opted to be a one-bot-server.


### PR DESCRIPTION
With the next Red update, we will be able to mention roles again using the ``allowed_mentions`` kwarg in .send methods.